### PR TITLE
Things I Forgot To Push

### DIFF
--- a/src/commands/rpg/RaidSubcommands.ts
+++ b/src/commands/rpg/RaidSubcommands.ts
@@ -470,9 +470,9 @@ const slashCommand: SlashCommandFile = {
                 fields: [
                     {
                         name: "Rewards:",
-                        value: `- **${(raid.baseRewards.coins ?? 0).toLocaleString(
+                        value: `> - **${(raid.baseRewards.coins ?? 0).toLocaleString(
                             "en-US"
-                        )}**${ctx.client.localEmojis.jocoins}\n- **${(
+                        )}**${ctx.client.localEmojis.jocoins}\n> - **${(
                             raid.baseRewards.xp ?? 0
                         ).toLocaleString("en-US")}**${
                             ctx.client.localEmojis.xp
@@ -487,7 +487,7 @@ const slashCommand: SlashCommandFile = {
                             .filter((r) => r)
                             .join("\n")}${
                             raid.baseRewards.items.length !== 0
-                                ? "\n\n\- The drop rate of an item is determined by the damage you deal.\nIf there is a 100% chance of getting an item, and you deal 50% damage, you'll have a 50% to get the item.\nThis logic applies to every reward."
+                                ? "\n\n\\- The drop rate of an item is determined by the damage you deal.\nIf there is a 100% chance of getting an item, and you deal 50% damage, you'll have a 50% to get the item.\nThis logic applies to every reward."
                                 : ""
                         }`,
                     },

--- a/src/rpg/SideQuests.ts
+++ b/src/rpg/SideQuests.ts
@@ -284,7 +284,7 @@ export const Echoes2: SideQuest = {
     requirementsMessage: "- You need to have **Echoes** to do this quest and be level **10**",
     quests: (ctx) => {
         const baseQuests: QuestArray = [
-            Functions.generateUseXCommandQuest("assault", 25),
+            Functions.generateUseXCommandQuest("assault", 20),
             Functions.generateClaimXQuest("daily", 2),
             Functions.generataRaidQuest(Raids.BanditBoss.boss),
         ];
@@ -323,7 +323,7 @@ export const Echoes3: SideQuest = {
     requirementsMessage: "- You need to have **Echoes Act 2** to do this quest and be level **15**",
     quests: (ctx) => {
         const baseQuests: QuestArray = [
-            Functions.generateUseXCommandQuest("assault", 50),
+            Functions.generateUseXCommandQuest("assault", 30),
             Functions.generateClaimXQuest("daily", 1),
             Functions.generataRaidQuest(Raids.BanditBoss.boss),
             Functions.generataRaidQuest(Raids.BanditBoss.boss),

--- a/src/rpg/Stands/Stands.ts
+++ b/src/rpg/Stands/Stands.ts
@@ -768,7 +768,7 @@ export const Horus: Stand = {
 
 export const AdminStand: Stand = {
     id: "admin_stand",
-    name: "The WICKED",
+    name: "The WICKED [Staff Only]",
     description: "Enchant the power of the wicked through yourself. **[Staff Only]**",
     rarity: "SS",
     image: "https://media.jolyne.moe/UWAEPT/direct",
@@ -812,7 +812,7 @@ export const YellowTemperance: Stand = {
 
 export const TheFemboy: Stand = {
     id: "the_femboy",
-    name: "The Femboy",
+    name: "The Femboy [Unobtainable]",
     rarity: "SS",
     description:
         "The Femboy is a Stand with the ability to make anyone horny, providing its user with an incredible defense. [limited custom stand]",


### PR DESCRIPTION
**Reduced Echoes Requirements**: So Act2 min level is 10, but from 25 assaults users are more like level 16 (if they even manage to do that). For Act3, 50 assaults are too much for a new user to do.

**Add Flairs to Stand Names**: Basically to distinguish between these stands in `/stand list`. I don't think it would break anything, cause you use `id`s instead of `name` to call/filter them right?